### PR TITLE
Add MCP server setup for Claude Code and Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ nix develop --command just setup
 
 ```
 flake.nix              ← declares all packages (Nix devShell)
-justfile               ← recipes: setup, link, zshrc, npm, status, clean, update
+justfile               ← recipes: setup, link, zshrc, npm, mcp, status, clean, update
 bootstrap.sh           ← one-time script (Xcode CLI + Nix)
 shell/zshrc_block.zsh  ← shell config injected into ~/.zshrc
 nvim/                  ← Neovim config (symlinked to ~/.config/nvim)
 tmux/                  ← tmux config (symlinked to ~/.tmux.conf)
+mcp/                   ← MCP server templates (GitHub, Jira, Slack, Linear, Notion)
 ```
 
 **Install flow:** `bootstrap.sh` → `nix develop` → `just setup`
@@ -60,7 +61,11 @@ tmux/                  ← tmux config (symlinked to ~/.tmux.conf)
 | `just link` | Symlinks nvim/ and tmux.conf (with backup) |
 | `just zshrc` | Injects shell block into ~/.zshrc between markers |
 | `just npm` | Installs npm globals not covered by Nix |
-| `just status` | Shows current state (symlinks, packages, shell block) |
+| `just mcp` | Interactive MCP server setup (GitHub, Jira, Slack, etc.) |
+| `just mcp github` | Configure a specific MCP server |
+| `just mcp-list` | List available MCP server templates |
+| `just mcp-status` | Show configured MCP servers |
+| `just status` | Shows current state (symlinks, packages, MCP, shell block) |
 | `just clean` | Removes symlinks and zshrc block |
 | `just update` | Runs `nix flake update` and `npm update -g` |
 
@@ -99,6 +104,38 @@ A marker-delimited block is injected into `~/.zshrc` (your existing config is pr
 - fzf shell integration
 - Starship prompt
 - Aliases and the `dev` function
+
+### MCP Servers (connect AI to external services)
+
+MCP (Model Context Protocol) lets Claude Code and Pi interact with external services — search Jira issues, create GitHub PRs, post to Slack, all from your AI coding session.
+
+**Available servers:**
+
+| Server | Service | Auth required |
+|--------|---------|---------------|
+| `github` | Issues, PRs, repos, code search | `gh auth login` |
+| `jira` | Jira issues, Confluence pages | Atlassian API token |
+| `slack` | Channels, messages, threads | Slack bot token |
+| `linear` | Issues, projects, teams | Linear API key |
+| `notion` | Pages, databases, search | Notion API key |
+
+**Quick setup:**
+
+```bash
+# Interactive — pick which servers to enable
+nix develop --command just mcp
+
+# Direct — configure specific servers
+nix develop --command just mcp github
+nix develop --command just mcp github jira slack
+
+# Check what's configured
+just mcp-status
+```
+
+GitHub is zero-config if you've already run `gh auth login` — it uses the GitHub CLI directly.
+
+For token-based services (Jira, Slack, etc.), the setup will prompt for credentials or read them from environment variables. Templates are in `mcp/` — add your own by dropping a JSON file there.
 
 ### Pi (primary AI interface)
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,130 @@
+{
+  "nodes": {
+    "claude-code-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1773279046,
+        "narHash": "sha256-k1S9VEaiRgRrfwolWKV+n3YKpfnQCoE+3M9BDrWVwyI=",
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "rev": "00189c0d55fd64d8f7880979d9f91dcb675996e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773110118,
+        "narHash": "sha256-mPAG8phMbCReKSiKAijjjd3v7uVcJOQ75gSjGJjt/Rk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e607cb5360ff1234862ac9f8839522becb853bb9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1773201692,
+        "narHash": "sha256-NXrKzNMniu4Oam2kAFvqJ3GB2kAvlAFIriTAheaY8hw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6067cc0127d4db9c26c79e4de0513e58d0c40c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "claude-code-nix": "claude-code-nix",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/justfile
+++ b/justfile
@@ -119,6 +119,10 @@ status:
     fi
 
     echo ""
+    echo "=== MCP servers ==="
+    python3 "{{ root }}/mcp/status.py" short
+
+    echo ""
     echo "=== Key binaries ==="
     for cmd in nvim tmux fzf claude node just; do
         if loc="$(command -v "$cmd" 2>/dev/null)"; then
@@ -153,6 +157,30 @@ clean:
     fi
 
     echo "done (nvim/ and tmux/ configs are still in this repo)"
+
+# Configure MCP servers for Claude Code / Pi
+# Usage: just mcp              (interactive picker)
+#        just mcp github       (single server)
+#        just mcp github jira  (multiple servers)
+mcp *SERVERS:
+    {{ root }}/mcp/setup.sh {{ SERVERS }}
+
+# List available MCP server templates
+mcp-list:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Available MCP servers:"
+    for f in "{{ root }}"/mcp/*.json; do
+        [[ -f "$f" ]] || continue
+        name="$(basename "$f" .json)"
+        desc=$(python3 -c "import json; d=json.load(open('$f')); k=list(d.keys())[0]; print(d[k].get('description',''))" 2>/dev/null || echo "")
+        echo "  $name — $desc"
+    done
+
+# Show MCP servers currently configured in Claude Code
+mcp-status:
+    @echo "=== MCP servers in ~/.claude.json ==="
+    @python3 "{{ root }}/mcp/status.py" full
 
 # Update flake and npm globals
 update:

--- a/mcp/github.json
+++ b/mcp/github.json
@@ -1,0 +1,8 @@
+{
+  "github": {
+    "command": "gh",
+    "args": ["mcp"],
+    "description": "GitHub — issues, PRs, repos, code search via GitHub CLI",
+    "requires": "gh auth login"
+  }
+}

--- a/mcp/jira.json
+++ b/mcp/jira.json
@@ -1,0 +1,12 @@
+{
+  "jira": {
+    "command": "npx",
+    "args": ["-y", "@anthropic/mcp-server-atlassian"],
+    "env": {
+      "ATLASSIAN_SITE": "__JIRA_SITE__",
+      "ATLASSIAN_USER_EMAIL": "__JIRA_EMAIL__",
+      "ATLASSIAN_API_TOKEN": "__JIRA_API_TOKEN__"
+    },
+    "description": "Jira & Confluence — issues, boards, pages via Atlassian MCP"
+  }
+}

--- a/mcp/linear.json
+++ b/mcp/linear.json
@@ -1,0 +1,10 @@
+{
+  "linear": {
+    "command": "npx",
+    "args": ["-y", "@anthropic/mcp-server-linear"],
+    "env": {
+      "LINEAR_API_KEY": "__LINEAR_API_KEY__"
+    },
+    "description": "Linear — issues, projects, teams via Linear MCP"
+  }
+}

--- a/mcp/notion.json
+++ b/mcp/notion.json
@@ -1,0 +1,10 @@
+{
+  "notion": {
+    "command": "npx",
+    "args": ["-y", "@anthropic/mcp-server-notion"],
+    "env": {
+      "NOTION_API_KEY": "__NOTION_API_KEY__"
+    },
+    "description": "Notion — pages, databases, search via Notion MCP"
+  }
+}

--- a/mcp/setup.sh
+++ b/mcp/setup.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# shellsmith MCP server setup
+# Reads JSON templates from mcp/ dir, substitutes env vars, and writes
+# to Claude Code's global config (~/.claude.json mcpServers section).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_CONFIG="$HOME/.claude.json"
+AVAILABLE_SERVERS=()
+SELECTED_SERVERS=()
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Discover available MCP server templates
+for f in "$SCRIPT_DIR"/*.json; do
+    [[ -f "$f" ]] || continue
+    name="$(basename "$f" .json)"
+    AVAILABLE_SERVERS+=("$name")
+done
+
+if [[ ${#AVAILABLE_SERVERS[@]} -eq 0 ]]; then
+    echo -e "${RED}No MCP server templates found in $SCRIPT_DIR${NC}"
+    exit 1
+fi
+
+# Show menu
+echo -e "${CYAN}shellsmith MCP setup${NC}"
+echo ""
+echo "Available MCP servers:"
+for i in "${!AVAILABLE_SERVERS[@]}"; do
+    name="${AVAILABLE_SERVERS[$i]}"
+    desc=$(python3 -c "
+import json, sys
+with open('$SCRIPT_DIR/$name.json') as f:
+    d = json.load(f)
+key = list(d.keys())[0]
+print(d[key].get('description', ''))
+" 2>/dev/null || echo "")
+    echo -e "  ${GREEN}$((i+1)))${NC} $name — $desc"
+done
+echo ""
+
+# Parse arguments or prompt
+if [[ $# -gt 0 ]]; then
+    SELECTED_SERVERS=("$@")
+else
+    echo -n "Enter server names (space-separated) or 'all': "
+    read -r selection
+    if [[ "$selection" == "all" ]]; then
+        SELECTED_SERVERS=("${AVAILABLE_SERVERS[@]}")
+    else
+        read -ra SELECTED_SERVERS <<< "$selection"
+    fi
+fi
+
+# Validate selections
+for srv in "${SELECTED_SERVERS[@]}"; do
+    if [[ ! -f "$SCRIPT_DIR/$srv.json" ]]; then
+        echo -e "${RED}Unknown server: $srv${NC}"
+        exit 1
+    fi
+done
+
+# Ensure claude config exists
+if [[ ! -f "$CLAUDE_CONFIG" ]]; then
+    echo '{}' > "$CLAUDE_CONFIG"
+fi
+
+# Process each selected server
+for srv in "${SELECTED_SERVERS[@]}"; do
+    template="$SCRIPT_DIR/$srv.json"
+    echo ""
+    echo -e "${CYAN}Configuring: $srv${NC}"
+
+    # Read the template and extract env placeholders
+    server_json=$(cat "$template")
+    key=$(python3 -c "import json; d=json.load(open('$template')); print(list(d.keys())[0])")
+
+    # Check for requires field
+    requires=$(python3 -c "
+import json
+d = json.load(open('$template'))
+key = list(d.keys())[0]
+print(d[key].get('requires', ''))
+" 2>/dev/null || echo "")
+
+    if [[ -n "$requires" ]]; then
+        echo -e "  ${YELLOW}prerequisite:${NC} $requires"
+    fi
+
+    # Find placeholders (__SOMETHING__) and prompt for values
+    placeholders=$(grep -oE '__[A-Z_]+__' "$template" 2>/dev/null | sort -u || true)
+
+    resolved_json="$server_json"
+    skip=false
+    for ph in $placeholders; do
+        # Convert __JIRA_SITE__ → JIRA_SITE for display
+        var_name="${ph//__/}"
+
+        # Check if already set in environment
+        env_val="${!var_name:-}"
+        if [[ -n "$env_val" ]]; then
+            echo -e "  ${GREEN}$var_name${NC}: using env value"
+            resolved_json="${resolved_json//$ph/$env_val}"
+        else
+            echo -n "  $var_name: "
+            read -r user_val
+            if [[ -z "$user_val" ]]; then
+                echo -e "  ${YELLOW}skipping $srv (no value provided)${NC}"
+                skip=true
+                break
+            fi
+            resolved_json="${resolved_json//$ph/$user_val}"
+        fi
+    done
+
+    if [[ "$skip" == "true" ]]; then
+        continue
+    fi
+
+    # Merge into Claude Code config using python
+    python3 -c "
+import json, sys
+
+with open('$CLAUDE_CONFIG', 'r') as f:
+    config = json.load(f)
+
+template = json.loads('''$resolved_json''')
+key = list(template.keys())[0]
+
+# Build clean server entry (command, args, env only)
+entry = {}
+for field in ('command', 'args', 'env'):
+    if field in template[key]:
+        entry[field] = template[key][field]
+
+# Write to mcpServers at top level
+if 'mcpServers' not in config:
+    config['mcpServers'] = {}
+config['mcpServers'][key] = entry
+
+with open('$CLAUDE_CONFIG', 'w') as f:
+    json.dump(config, f, indent=2)
+"
+    echo -e "  ${GREEN}✓ $srv added to ~/.claude.json${NC}"
+done
+
+echo ""
+echo -e "${GREEN}MCP setup complete.${NC} Restart Claude Code or Pi to pick up changes."

--- a/mcp/slack.json
+++ b/mcp/slack.json
@@ -1,0 +1,10 @@
+{
+  "slack": {
+    "command": "npx",
+    "args": ["-y", "@anthropic/mcp-server-slack"],
+    "env": {
+      "SLACK_BOT_TOKEN": "__SLACK_BOT_TOKEN__"
+    },
+    "description": "Slack — channels, messages, threads via Slack MCP"
+  }
+}

--- a/mcp/status.py
+++ b/mcp/status.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Show MCP server status from Claude Code config."""
+import json
+import os
+import sys
+
+config_path = os.path.expanduser("~/.claude.json")
+mode = sys.argv[1] if len(sys.argv) > 1 else "short"
+
+if not os.path.exists(config_path):
+    print("  no config found")
+    sys.exit(0)
+
+with open(config_path) as f:
+    config = json.load(f)
+
+servers = config.get("mcpServers", {})
+if not servers:
+    if mode == "short":
+        print("  none configured (run: just mcp)")
+    else:
+        print("  none configured")
+    sys.exit(0)
+
+for name, srv in servers.items():
+    if mode == "short":
+        print(f"  ok: {name}")
+    else:
+        cmd = srv.get("command", "?")
+        args = " ".join(srv.get("args", []))
+        print(f"  {name}: {cmd} {args}")


### PR DESCRIPTION
## Summary
- Adds `mcp/` directory with ready-to-use MCP server templates for **GitHub**, **Jira**, **Slack**, **Linear**, and **Notion**
- Adds `just mcp` interactive recipe that configures MCP servers in `~/.claude.json` for Claude Code / Pi
- Adds `just mcp-list` and `just mcp-status` helper recipes
- Updates `just status` to show configured MCP servers
- GitHub is zero-config (uses `gh` CLI directly); token-based services prompt for credentials or read from env vars
- Templates are extensible — drop a JSON file in `mcp/` to add a new server

## Usage
```bash
# Interactive setup
nix develop --command just mcp

# Configure specific servers
nix develop --command just mcp github
nix develop --command just mcp github jira slack

# Check status
just mcp-list
just mcp-status
```

## Test plan
- [x] `just mcp-list` shows all 5 server templates
- [x] `just mcp-status` shows configured servers (or "none configured")
- [x] `just mcp github` adds GitHub MCP to `~/.claude.json`
- [x] `just status` includes MCP section
- [x] Token-based servers (Jira, Slack, etc.) prompt for credentials
- [x] Idempotent — safe to run multiple times

🤖 Generated with [Claude Code](https://claude.com/claude-code)