### PR TITLE
Fix Telescope command error on dev session startup

### DIFF
--- a/shell/zshrc_block.zsh
+++ b/shell/zshrc_block.zsh
@@ -31,7 +31,7 @@ alias orch='python3 ~/.shellsmith/orchestrator/orch.py'
 # Dev session: Neovim on top, Pi on bottom
 dev() {
   local session="${1:-dev}"
-  tmux new-session -d -s "$session" -n code 'nvim +Telescope\ find_files'
+  tmux new-session -d -s "$session" -n code 'nvim "+lua vim.defer_fn(function() vim.cmd(\"Telescope find_files\") end, 0)"'
   tmux split-window -v -t "$session" -l 30% 'pi'
   tmux select-pane -t "$session:1.1"
   tmux attach -t "$session"


### PR DESCRIPTION
Defer Telescope find_files call so it runs after lazy.nvim loads plugins, fixing "E492: Not an editor command" error.