### PR TITLE
Fix Telescope startup error in dev session

### DIFF
--- a/shell/zshrc_block.zsh
+++ b/shell/zshrc_block.zsh
@@ -31,7 +31,7 @@ alias orch='python3 ~/.shellsmith/orchestrator/orch.py'
 # Dev session: Neovim on top, Pi on bottom
 dev() {
   local session="${1:-dev}"
-  tmux new-session -d -s "$session" -n code 'nvim "+lua vim.defer_fn(function() vim.cmd(\"Telescope find_files\") end, 0)"'
+  tmux new-session -d -s "$session" -n code 'nvim "+lua vim.defer_fn(function() require(\"telescope.builtin\").find_files() end, 100)"'
   tmux split-window -v -t "$session" -l 30% 'pi'
   tmux select-pane -t "$session:1.1"
   tmux attach -t "$session"


### PR DESCRIPTION
## Summary
- Fix `E492: Not an editor command: Telescope find_files` when running `dev` shell function
- Use `require("telescope.builtin").find_files()` instead of `vim.cmd("Telescope find_files")` — the `require` call triggers lazy.nvim's module loader to force-load the plugin
- Add 100ms delay via `vim.defer_fn` to ensure Neovim initialization is complete

## Root cause
Two issues combined:
1. **Stale symlinks** — `~/.config/nvim` pointed to the old `development-wf/nvim` (doesn't exist) instead of `shellsmith/nvim`, so Neovim loaded with no config at all. Fix: re-run `just link` (or `ln -sfn ~/shellsmith/nvim ~/.config/nvim`)
2. **Fragile startup command** — even with correct symlinks, `vim.cmd("Telescope find_files")` can fail if lazy.nvim hasn't registered the `:Telescope` command yet. Using `require("telescope.builtin")` is more robust as it triggers lazy.nvim's module loader directly.

## Test plan
- [ ] Ensure `~/.config/nvim` symlink points to `shellsmith/nvim` (run `just link`)
- [ ] Run `dev` and confirm Telescope file picker opens without errors
- [ ] Confirm tmux layout still works (Neovim top pane, Pi bottom pane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)