### PR TITLE
Integrate ralph as orchestrator execution engine

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
             pkgs.tmux
             pkgs.fd
             pkgs.fzf
+            pkgs.jq
             pkgs.lazygit
             pkgs.yazi
             pkgs.starship

--- a/justfile
+++ b/justfile
@@ -122,7 +122,7 @@ status:
 
     echo ""
     echo "=== Key binaries ==="
-    for cmd in nvim tmux fzf claude node just; do
+    for cmd in nvim tmux fzf jq claude node just; do
         if loc="$(command -v "$cmd" 2>/dev/null)"; then
             echo "  ok: $cmd → $loc"
         else
@@ -191,6 +191,10 @@ orch-setup:
     pip3 install --user anthropic pyyaml
     mkdir -p ~/.local/share/shellsmith/orchestrator/tasks
     mkdir -p ~/.local/share/shellsmith/orchestrator/logs
+    mkdir -p ~/.local/share/shellsmith/orchestrator/workdirs
+    chmod +x {{ root }}/orchestrator/ralph/ralph.sh
+    @command -v jq >/dev/null || echo "WARNING: jq not found — enter nix develop shell"
+    @command -v claude >/dev/null || echo "WARNING: claude not found — enter nix develop shell"
     @echo "orchestrator: setup complete"
 
 # Submit a task for async planning
@@ -205,9 +209,13 @@ orch-status:
 orch-show ID:
     python3 {{ root }}/orchestrator/orch.py show {{ ID }}
 
-# Approve a planned task for execution
-orch-approve ID:
-    python3 {{ root }}/orchestrator/orch.py approve {{ ID }}
+# Approve a planned task — launches ralph in background
+orch-approve ID *ARGS:
+    python3 {{ root }}/orchestrator/orch.py approve {{ ID }} {{ ARGS }}
+
+# Show ralph story progress for a task
+orch-stories ID:
+    python3 {{ root }}/orchestrator/orch.py stories {{ ID }}
 
 # Cancel an orchestrator task
 orch-cancel ID:

--- a/orchestrator/orch.py
+++ b/orchestrator/orch.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
-"""Orchestrator: async plan-and-execute pipeline via Anthropic API.
+"""Orchestrator: async plan-and-execute pipeline via Anthropic API + ralph.
 
-Dispatches tasks to a thinking model for planning, then to a smaller model
-for execution. All work happens in background processes — the CLI never blocks.
+Plans tasks with a thinking model, then executes autonomously via ralph —
+a bash loop that spawns fresh Claude Code instances per user story.
 
 State: flat JSON files in ~/.local/share/shellsmith/orchestrator/tasks/<id>.json
-Logs:  ~/.local/share/shellsmith/orchestrator/logs/<id>-{plan,execute}.log
+Logs:  ~/.local/share/shellsmith/orchestrator/logs/<id>-{plan,ralph}.log
 """
 
 import argparse
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
 import tempfile
-import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,7 +26,11 @@ import yaml
 DATA_DIR = Path.home() / ".local" / "share" / "shellsmith" / "orchestrator"
 TASKS_DIR = DATA_DIR / "tasks"
 LOGS_DIR = DATA_DIR / "logs"
+WORKDIRS_DIR = DATA_DIR / "workdirs"
 PIPELINE_DIR = Path(__file__).resolve().parent / "pipelines"
+RALPH_DIR = Path(__file__).resolve().parent / "ralph"
+RALPH_SCRIPT = RALPH_DIR / "ralph.sh"
+RALPH_CLAUDE_TEMPLATE = RALPH_DIR / "CLAUDE.md.template"
 DEFAULT_PIPELINE = "plan-execute"
 
 # ── pipeline config ─────────────────────────────────────────────────────────
@@ -40,7 +44,7 @@ def load_pipeline(name=DEFAULT_PIPELINE):
 
 def get_model(step_name, pipeline):
     """Return model ID for a pipeline step, respecting env var overrides."""
-    env_map = {"plan": "ORCH_PLANNER_MODEL", "execute": "ORCH_EXECUTOR_MODEL"}
+    env_map = {"plan": "ORCH_PLANNER_MODEL"}
     env_var = env_map.get(step_name)
     if env_var and os.environ.get(env_var):
         return os.environ[env_var]
@@ -61,10 +65,15 @@ def get_step(step_name, pipeline):
 def ensure_dirs():
     TASKS_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    WORKDIRS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def task_path(task_id):
     return TASKS_DIR / f"{task_id}.json"
+
+
+def task_workdir(task_id):
+    return WORKDIRS_DIR / task_id
 
 
 def save_task(task):
@@ -127,9 +136,11 @@ def new_task(description):
         "created_at": now,
         "updated_at": now,
         "plan": None,
+        "prd": None,
         "result": None,
         "planner_pid": None,
         "executor_pid": None,
+        "ralph_workdir": None,
         "error": None,
     }
 
@@ -141,7 +152,6 @@ def die(msg):
 
 
 def pid_alive(pid):
-    """Check if a PID is still running."""
     if pid is None:
         return False
     try:
@@ -157,7 +167,6 @@ def check_api_key():
 
 
 def tmux_notify(msg):
-    """Send a tmux display-message notification (non-fatal if tmux isn't running)."""
     try:
         subprocess.run(
             ["tmux", "display-message", "-d", "5000", f"[orch] {msg}"],
@@ -168,21 +177,55 @@ def tmux_notify(msg):
         pass
 
 
+def read_live_prd(task):
+    """Read the live prd.json from ralph's workdir (ralph updates it as stories complete)."""
+    workdir = task.get("ralph_workdir")
+    if not workdir:
+        return None
+    prd_path = Path(workdir) / "prd.json"
+    if not prd_path.exists():
+        return None
+    try:
+        with open(prd_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
 def detect_stale(task):
-    """If a worker PID is recorded but dead, mark the task as failed."""
+    """If a worker PID is recorded but dead, update task status accordingly."""
     changed = False
     if task["status"] == "planning" and task.get("planner_pid"):
         if not pid_alive(task["planner_pid"]):
             task["status"] = "failed"
             task["error"] = "Planner process died unexpectedly"
+            task["planner_pid"] = None
             task["updated_at"] = datetime.now(timezone.utc).isoformat()
             changed = True
+
     if task["status"] == "executing" and task.get("executor_pid"):
         if not pid_alive(task["executor_pid"]):
-            task["status"] = "failed"
-            task["error"] = "Executor process died unexpectedly"
+            # Ralph exited — check if all stories passed
+            prd = read_live_prd(task)
+            if prd and prd.get("userStories"):
+                stories = prd["userStories"]
+                done = sum(1 for s in stories if s.get("passes"))
+                total = len(stories)
+                if done == total:
+                    task["status"] = "completed"
+                    task["result"] = (
+                        f"All {total} stories completed on branch {prd.get('branchName', '?')}"
+                    )
+                else:
+                    task["status"] = "failed"
+                    task["error"] = f"Ralph exited with {done}/{total} stories complete"
+            else:
+                task["status"] = "failed"
+                task["error"] = "Ralph process exited, could not read prd.json"
+            task["executor_pid"] = None
             task["updated_at"] = datetime.now(timezone.utc).isoformat()
             changed = True
+
     if changed:
         save_task(task)
     return task
@@ -260,7 +303,16 @@ def cmd_show(args):
         print("--- Error ---")
         print(task["error"])
 
-    if task.get("plan"):
+    if task.get("prd"):
+        print()
+        print("--- PRD ---")
+        prd = task["prd"]
+        print(f"Branch: {prd.get('branchName', '?')}")
+        print(f"Stories: {len(prd.get('userStories', []))}")
+        for s in prd.get("userStories", []):
+            mark = "PASS" if s.get("passes") else "    "
+            print(f"  [{mark}] {s['id']}  P{s.get('priority', '?')}  {s['title']}")
+    elif task.get("plan"):
         print()
         print("--- Plan ---")
         print(task["plan"])
@@ -272,7 +324,6 @@ def cmd_show(args):
 
 
 def cmd_approve(args):
-    check_api_key()
     task_id = resolve_id(args.id)
     task = load_task(task_id)
     if not task:
@@ -281,25 +332,100 @@ def cmd_approve(args):
     if task["status"] != "planned":
         die(f"Task {task_id} is '{task['status']}', must be 'planned' to approve")
 
+    if not task.get("prd"):
+        die(f"Task {task_id} has no valid PRD. Run: orch show {task_id}")
+
+    prd = task["prd"]
+
+    # Create per-task working directory
+    workdir = task_workdir(task_id)
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    # Write prd.json
+    prd_path = workdir / "prd.json"
+    with open(prd_path, "w") as f:
+        json.dump(prd, f, indent=2)
+
+    # Write CLAUDE.md from template
+    claude_md_path = workdir / "CLAUDE.md"
+    template = RALPH_CLAUDE_TEMPLATE.read_text()
+    claude_md_path.write_text(template)
+
+    # Initialize progress.txt
+    progress_path = workdir / "progress.txt"
+    progress_path.write_text(
+        f"# Ralph Progress Log\n"
+        f"Task: {task_id}\n"
+        f"Description: {task['description']}\n"
+        f"Started: {datetime.now(timezone.utc).isoformat()}\n"
+        f"---\n"
+    )
+
+    # Update task state
     task["status"] = "executing"
+    task["ralph_workdir"] = str(workdir)
     task["updated_at"] = datetime.now(timezone.utc).isoformat()
     save_task(task)
 
-    log_path = LOGS_DIR / f"{task_id}-execute.log"
+    # Launch ralph in background
+    log_path = LOGS_DIR / f"{task_id}-ralph.log"
     log_file = open(log_path, "w")
 
+    max_iters = str(args.iterations)
+
+    env = {
+        **os.environ,
+        "RALPH_PRD_FILE": str(prd_path),
+        "RALPH_PROGRESS_FILE": str(progress_path),
+        "RALPH_PROMPT_FILE": str(claude_md_path),
+    }
+
     proc = subprocess.Popen(
-        [sys.executable, __file__, "_execute", task_id],
+        [str(RALPH_SCRIPT), "--tool", "claude", max_iters],
         start_new_session=True,
         stdout=log_file,
         stderr=subprocess.STDOUT,
-        env={**os.environ},
+        cwd=str(Path.cwd()),  # run in the project repo root
+        env=env,
     )
 
     task["executor_pid"] = proc.pid
     save_task(task)
 
-    print(f"Task {task_id} approved — executing in background (pid {proc.pid})")
+    stories = prd.get("userStories", [])
+    print(f"Task {task_id} approved — ralph running in background (pid {proc.pid})")
+    print(f"  Stories: {len(stories)}")
+    print(f"  Branch:  {prd.get('branchName', '?')}")
+    print(f"  Logs:    orch logs {task_id}")
+
+
+def cmd_stories(args):
+    """Show live ralph story progress by reading the workdir's prd.json."""
+    task_id = resolve_id(args.id)
+    task = load_task(task_id)
+    if not task:
+        die(f"Task not found: {task_id}")
+
+    prd = read_live_prd(task)
+    if not prd:
+        # Fall back to task's original prd
+        prd = task.get("prd")
+    if not prd:
+        die(f"Task {task_id} has no PRD data")
+
+    stories = prd.get("userStories", [])
+    total = len(stories)
+    done = sum(1 for s in stories if s.get("passes"))
+
+    print(f"Task:   {task_id}")
+    print(f"Branch: {prd.get('branchName', '?')}  ({done}/{total} complete)")
+    if task.get("executor_pid"):
+        alive = pid_alive(task["executor_pid"])
+        print(f"Ralph:  pid {task['executor_pid']} ({'running' if alive else 'stopped'})")
+    print()
+    for s in stories:
+        mark = "PASS" if s.get("passes") else "    "
+        print(f"  [{mark}] {s['id']}  P{s.get('priority', '?')}  {s['title']}")
 
 
 def cmd_cancel(args):
@@ -311,7 +437,6 @@ def cmd_cancel(args):
     if task["status"] in ("completed", "cancelled"):
         die(f"Task {task_id} is already '{task['status']}'")
 
-    # Kill worker if running
     for pid_key in ("planner_pid", "executor_pid"):
         pid = task.get(pid_key)
         if pid and pid_alive(pid):
@@ -333,11 +458,19 @@ def cmd_logs(args):
     if not task:
         die(f"Task not found: {task_id}")
 
-    for suffix in ("plan", "execute"):
+    for suffix in ("plan", "ralph"):
         log_path = LOGS_DIR / f"{task_id}-{suffix}.log"
         if log_path.exists():
             print(f"=== {suffix} log ===")
             print(log_path.read_text())
+            print()
+
+    # Also show ralph progress.txt
+    if task.get("ralph_workdir"):
+        progress = Path(task["ralph_workdir"]) / "progress.txt"
+        if progress.exists():
+            print("=== ralph progress ===")
+            print(progress.read_text())
             print()
 
 
@@ -364,21 +497,41 @@ def cmd_plan(args):
         client = anthropic.Anthropic()
         response = client.messages.create(
             model=model,
-            max_tokens=step.get("max_tokens", 4096),
+            max_tokens=step.get("max_tokens", 8192),
             system=step["system_prompt"].strip(),
             messages=[{"role": "user", "content": task["description"]}],
         )
         plan_text = response.content[0].text
 
+        # Validate plan as prd.json
         task = load_task(task_id)  # re-read in case of concurrent update
         task["plan"] = plan_text
-        task["status"] = "planned"
         task["planner_pid"] = None
+
+        try:
+            prd = json.loads(plan_text)
+            assert "branchName" in prd, "Missing branchName"
+            assert "userStories" in prd, "Missing userStories"
+            assert len(prd["userStories"]) > 0, "No user stories"
+            for story in prd["userStories"]:
+                assert "id" in story and "title" in story, "Story missing required fields"
+
+            task["prd"] = prd
+            task["status"] = "planned"
+            print(f"[plan] Valid PRD with {len(prd['userStories'])} stories")
+        except (json.JSONDecodeError, AssertionError) as e:
+            task["status"] = "plan_invalid"
+            task["error"] = f"Plan is not valid PRD JSON: {e}"
+            print(f"[plan] WARNING: Plan output is not valid PRD JSON: {e}")
+
         task["updated_at"] = datetime.now(timezone.utc).isoformat()
         save_task(task)
 
-        print(f"[plan] Done — status set to 'planned'")
-        tmux_notify(f"Task {task_id} planned — run: orch show {task_id}")
+        if task["status"] == "planned":
+            print(f"[plan] Done — status set to 'planned'")
+            tmux_notify(f"Task {task_id} planned — run: orch show {task_id}")
+        else:
+            tmux_notify(f"Task {task_id} plan_invalid — check: orch show {task_id}")
 
     except Exception as e:
         error_type = type(e).__name__
@@ -394,71 +547,11 @@ def cmd_plan(args):
         sys.exit(1)
 
 
-def cmd_execute(args):
-    """Internal: called as a background worker to run the executor."""
-    import anthropic
-
-    task_id = args.id
-    task = load_task(task_id)
-    if not task:
-        print(f"Task not found: {task_id}", file=sys.stderr)
-        sys.exit(1)
-
-    if not task.get("plan"):
-        print(f"Task {task_id} has no plan", file=sys.stderr)
-        sys.exit(1)
-
-    pipeline = load_pipeline()
-    step = get_step("execute", pipeline)
-    model = get_model("execute", pipeline)
-
-    print(f"[execute] Starting executor for task {task_id}")
-    print(f"[execute] Model: {model}")
-
-    user_message = (
-        f"## Task\n{task['description']}\n\n"
-        f"## Approved Plan\n{task['plan']}"
-    )
-
-    try:
-        client = anthropic.Anthropic()
-        response = client.messages.create(
-            model=model,
-            max_tokens=step.get("max_tokens", 8192),
-            system=step["system_prompt"].strip(),
-            messages=[{"role": "user", "content": user_message}],
-        )
-        result_text = response.content[0].text
-
-        task = load_task(task_id)
-        task["result"] = result_text
-        task["status"] = "completed"
-        task["executor_pid"] = None
-        task["updated_at"] = datetime.now(timezone.utc).isoformat()
-        save_task(task)
-
-        print(f"[execute] Done — status set to 'completed'")
-        tmux_notify(f"Task {task_id} completed — run: orch show {task_id}")
-
-    except Exception as e:
-        error_type = type(e).__name__
-        task = load_task(task_id)
-        task["status"] = "failed"
-        task["error"] = f"{error_type}: {e}"
-        task["executor_pid"] = None
-        task["updated_at"] = datetime.now(timezone.utc).isoformat()
-        save_task(task)
-
-        print(f"[execute] Failed: {error_type}: {e}", file=sys.stderr)
-        tmux_notify(f"Task {task_id} FAILED: {error_type}")
-        sys.exit(1)
-
-
 # ── CLI ──────────────────────────────────────────────────────────────────────
 def main():
     parser = argparse.ArgumentParser(
         prog="orch",
-        description="Async plan-and-execute orchestrator",
+        description="Async plan-and-execute orchestrator (powered by ralph)",
     )
     sub = parser.add_subparsers(dest="command")
 
@@ -470,8 +563,14 @@ def main():
     p_show = sub.add_parser("show", help="Show task details")
     p_show.add_argument("id", help="Task ID (prefix match supported)")
 
-    p_approve = sub.add_parser("approve", help="Approve plan and start execution")
+    p_approve = sub.add_parser("approve", help="Approve plan and start ralph execution")
     p_approve.add_argument("id", help="Task ID")
+    p_approve.add_argument(
+        "--iterations", type=int, default=10, help="Max ralph iterations (default: 10)"
+    )
+
+    p_stories = sub.add_parser("stories", help="Show ralph story progress")
+    p_stories.add_argument("id", help="Task ID")
 
     p_cancel = sub.add_parser("cancel", help="Cancel a task")
     p_cancel.add_argument("id", help="Task ID")
@@ -482,9 +581,6 @@ def main():
     # Internal worker commands (not shown in help)
     p_plan = sub.add_parser("_plan")
     p_plan.add_argument("id")
-
-    p_exec = sub.add_parser("_execute")
-    p_exec.add_argument("id")
 
     args = parser.parse_args()
 
@@ -497,10 +593,10 @@ def main():
         "status": cmd_status,
         "show": cmd_show,
         "approve": cmd_approve,
+        "stories": cmd_stories,
         "cancel": cmd_cancel,
         "logs": cmd_logs,
         "_plan": cmd_plan,
-        "_execute": cmd_execute,
     }
 
     dispatch[args.command](args)

--- a/orchestrator/pipelines/plan-execute.yaml
+++ b/orchestrator/pipelines/plan-execute.yaml
@@ -1,19 +1,37 @@
 name: plan-execute
-description: Plan with a strong model, execute with a fast model
+description: Plan with a strong model, execute autonomously via ralph loop
 steps:
   - name: plan
     model: claude-sonnet-4-5-20250929
-    max_tokens: 4096
-    system_prompt: |
-      You are a senior software architect. Given a task, create a clear,
-      actionable implementation plan with specific steps. Include file paths
-      and function names where possible.
-    requires_approval: false
-  - name: execute
-    model: claude-haiku-4-5-20251001
     max_tokens: 8192
     system_prompt: |
-      You are a precise code implementer. Given a task and an approved plan,
-      implement each step. Output code changes as clearly labeled file blocks.
-    input_from: plan
-    requires_approval: true
+      You are a senior software architect. Given a task, create a clear,
+      actionable implementation plan structured as user stories for an
+      autonomous coding agent.
+
+      Output ONLY a valid JSON object with this exact schema:
+      {
+        "project": "<short project name>",
+        "branchName": "ralph/<kebab-case-feature-name>",
+        "description": "<one-line summary>",
+        "userStories": [
+          {
+            "id": "US-001",
+            "title": "<short title>",
+            "description": "<what and why>",
+            "acceptanceCriteria": ["<criterion 1>", "<criterion 2>"],
+            "priority": 1,
+            "passes": false,
+            "notes": ""
+          }
+        ]
+      }
+
+      Rules:
+      - Each story must fit in a single Claude Code context window (~30 min of work)
+      - Stories must be ordered by dependency (priority 1 = do first)
+      - Acceptance criteria must be concrete and testable
+      - Include file paths and function names where possible
+      - branchName must start with "ralph/"
+      - Output raw JSON only — no markdown fences, no commentary
+    requires_approval: false

--- a/orchestrator/ralph/CLAUDE.md.template
+++ b/orchestrator/ralph/CLAUDE.md.template
@@ -1,0 +1,86 @@
+# Ralph Agent Instructions
+
+You are an autonomous coding agent working on the shellsmith project.
+
+## Your Task
+
+1. Read the PRD at `prd.json` (path provided via RALPH_PRD_FILE env var, or same directory as this file)
+2. Read the progress log at `progress.txt` (check Codebase Patterns section first)
+3. Check you're on the correct branch from PRD `branchName`. If not, check it out or create from main.
+4. Pick the **highest priority** user story where `passes: false`
+5. Implement that single user story
+6. Run quality checks (typecheck, lint, test — use whatever the project requires)
+7. Update CLAUDE.md files if you discover reusable patterns (see below)
+8. If checks pass, commit ALL changes with message: `feat: [Story ID] - [Story Title]`
+9. Update the PRD to set `passes: true` for the completed story
+10. Append your progress to `progress.txt`
+
+## Project Conventions
+
+- **Package management:** Nix flake (`flake.nix`) — do NOT use brew, apt, or manual installs
+- **Task runner:** `just` (justfile) — check existing recipes before adding new ones
+- **Shell config:** managed via shellsmith markers in `~/.zshrc`
+- **Config symlinks:** managed via `just link`
+- **AI tools:** Claude Code is available in the Nix dev shell
+
+## Progress Report Format
+
+APPEND to progress.txt (never replace, always append):
+```
+## [Date/Time] - [Story ID]
+- What was implemented
+- Files changed
+- **Learnings for future iterations:**
+  - Patterns discovered (e.g., "this codebase uses X for Y")
+  - Gotchas encountered (e.g., "don't forget to update Z when changing W")
+  - Useful context (e.g., "the evaluation panel is in component X")
+---
+```
+
+The learnings section is critical — it helps future iterations avoid repeating mistakes.
+
+## Consolidate Patterns
+
+If you discover a **reusable pattern**, add it to the `## Codebase Patterns` section at the TOP of progress.txt (create it if it doesn't exist):
+
+```
+## Codebase Patterns
+- Example: Use Nix flake for all new dependencies
+- Example: Add just recipes for new automation tasks
+- Example: Symlink config files via `just link`
+```
+
+Only add patterns that are **general and reusable**, not story-specific details.
+
+## Update CLAUDE.md Files
+
+Before committing, check if any edited files have learnings worth preserving in nearby CLAUDE.md files:
+
+1. **Identify directories with edited files**
+2. **Check for existing CLAUDE.md** in those directories or parents
+3. **Add valuable learnings** — API patterns, gotchas, dependencies, testing approaches
+
+**Do NOT add:** story-specific details, temporary debugging notes, information already in progress.txt.
+
+## Quality Requirements
+
+- ALL commits must pass quality checks
+- Do NOT commit broken code
+- Keep changes focused and minimal
+- Follow existing code patterns
+
+## Stop Condition
+
+After completing a user story, check if ALL stories have `passes: true`.
+
+If ALL stories are complete and passing, reply with:
+<promise>COMPLETE</promise>
+
+If there are still stories with `passes: false`, end your response normally (another iteration will pick up the next story).
+
+## Important
+
+- Work on ONE story per iteration
+- Commit frequently
+- Keep CI green
+- Read the Codebase Patterns section in progress.txt before starting

--- a/orchestrator/ralph/ralph.sh
+++ b/orchestrator/ralph/ralph.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Ralph Wiggum - Long-running AI agent loop
+# Vendored from github.com/snarktank/ralph with env-var path overrides
+# for orchestrator integration.
+#
+# Usage: ./ralph.sh [--tool amp|claude] [max_iterations]
+
+set -e
+
+# Parse arguments
+TOOL="claude"  # Default to claude for shellsmith
+MAX_ITERATIONS=10
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --tool)
+      TOOL="$2"
+      shift 2
+      ;;
+    --tool=*)
+      TOOL="${1#*=}"
+      shift
+      ;;
+    *)
+      if [[ "$1" =~ ^[0-9]+$ ]]; then
+        MAX_ITERATIONS="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ "$TOOL" != "amp" && "$TOOL" != "claude" ]]; then
+  echo "Error: Invalid tool '$TOOL'. Must be 'amp' or 'claude'."
+  exit 1
+fi
+
+# Paths — env vars allow orchestrator to point at per-task workdirs
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRD_FILE="${RALPH_PRD_FILE:-$SCRIPT_DIR/prd.json}"
+PROGRESS_FILE="${RALPH_PROGRESS_FILE:-$SCRIPT_DIR/progress.txt}"
+PROMPT_FILE="${RALPH_PROMPT_FILE:-$SCRIPT_DIR/CLAUDE.md}"
+ARCHIVE_DIR="${RALPH_ARCHIVE_DIR:-$SCRIPT_DIR/archive}"
+LAST_BRANCH_FILE="${RALPH_LAST_BRANCH_FILE:-$SCRIPT_DIR/.last-branch}"
+
+# Archive previous run if branch changed
+if [ -f "$PRD_FILE" ] && [ -f "$LAST_BRANCH_FILE" ]; then
+  CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
+  LAST_BRANCH=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
+
+  if [ -n "$CURRENT_BRANCH" ] && [ -n "$LAST_BRANCH" ] && [ "$CURRENT_BRANCH" != "$LAST_BRANCH" ]; then
+    DATE=$(date +%Y-%m-%d)
+    FOLDER_NAME=$(echo "$LAST_BRANCH" | sed 's|^ralph/||')
+    ARCHIVE_FOLDER="$ARCHIVE_DIR/$DATE-$FOLDER_NAME"
+
+    echo "Archiving previous run: $LAST_BRANCH"
+    mkdir -p "$ARCHIVE_FOLDER"
+    [ -f "$PRD_FILE" ] && cp "$PRD_FILE" "$ARCHIVE_FOLDER/"
+    [ -f "$PROGRESS_FILE" ] && cp "$PROGRESS_FILE" "$ARCHIVE_FOLDER/"
+    echo "   Archived to: $ARCHIVE_FOLDER"
+
+    echo "# Ralph Progress Log" > "$PROGRESS_FILE"
+    echo "Started: $(date)" >> "$PROGRESS_FILE"
+    echo "---" >> "$PROGRESS_FILE"
+  fi
+fi
+
+# Track current branch
+if [ -f "$PRD_FILE" ]; then
+  CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
+  if [ -n "$CURRENT_BRANCH" ]; then
+    echo "$CURRENT_BRANCH" > "$LAST_BRANCH_FILE"
+  fi
+fi
+
+# Initialize progress file if it doesn't exist
+if [ ! -f "$PROGRESS_FILE" ]; then
+  echo "# Ralph Progress Log" > "$PROGRESS_FILE"
+  echo "Started: $(date)" >> "$PROGRESS_FILE"
+  echo "---" >> "$PROGRESS_FILE"
+fi
+
+echo "Starting Ralph - Tool: $TOOL - Max iterations: $MAX_ITERATIONS"
+echo "  PRD:      $PRD_FILE"
+echo "  Progress: $PROGRESS_FILE"
+echo "  Prompt:   $PROMPT_FILE"
+
+for i in $(seq 1 $MAX_ITERATIONS); do
+  echo ""
+  echo "==============================================================="
+  echo "  Ralph Iteration $i of $MAX_ITERATIONS ($TOOL)"
+  echo "==============================================================="
+
+  if [[ "$TOOL" == "amp" ]]; then
+    OUTPUT=$(cat "$PROMPT_FILE" | amp --dangerously-allow-all 2>&1 | tee /dev/stderr) || true
+  else
+    OUTPUT=$(claude --dangerously-skip-permissions --print < "$PROMPT_FILE" 2>&1 | tee /dev/stderr) || true
+  fi
+
+  if echo "$OUTPUT" | grep -q "<promise>COMPLETE</promise>"; then
+    echo ""
+    echo "Ralph completed all tasks!"
+    echo "Completed at iteration $i of $MAX_ITERATIONS"
+    exit 0
+  fi
+
+  echo "Iteration $i complete. Continuing..."
+  sleep 2
+done
+
+echo ""
+echo "Ralph reached max iterations ($MAX_ITERATIONS) without completing all tasks."
+echo "Check $PROGRESS_FILE for status."
+exit 1


### PR DESCRIPTION
## Summary
- Replace the old Anthropic API executor with [ralph](https://github.com/snarktank/ralph) — a bash loop that spawns fresh Claude Code instances per user story
- Ralph prevents context window degradation by giving each story a clean context while carrying forward learnings via `progress.txt` and git history
- Execution is fully autonomous and runs in the background after approval

## Changes
- **orchestrator/ralph/ralph.sh** — Vendored from snarktank/ralph with env-var path overrides (`RALPH_PRD_FILE`, `RALPH_PROGRESS_FILE`, `RALPH_PROMPT_FILE`) for per-task workdirs
- **orchestrator/ralph/CLAUDE.md.template** — Shellsmith-specific prompt for each Claude Code instance (references Nix, just, project conventions)
- **orchestrator/pipelines/plan-execute.yaml** — Planner prompt now outputs `prd.json`-compatible structured JSON with user stories, acceptance criteria, and branch names
- **orchestrator/orch.py** — Rewritten approve flow writes `prd.json` + launches ralph in background; new `stories` command for live progress; enhanced stale detection reads prd.json for pass/fail
- **flake.nix** — Added `jq` (ralph dependency)
- **justfile** — Updated `orch-setup`, added `orch-stories`, added `jq` to status checks

## Flow
```
orch run "task"  →  planner generates PRD  →  orch approve <id>  →  ralph runs in background
                                                                  →  orch stories <id>  (monitor)
                                                                  →  orch logs <id>     (full logs)
```

## Test plan
- [ ] `orch run "add a hello world just recipe"` — verify planner outputs valid prd.json
- [ ] `orch approve <id>` — verify ralph starts in background, creates branch, writes code
- [ ] `orch stories <id>` — verify live story progress updates
- [ ] `orch cancel <id>` — verify ralph process group is killed
- [ ] `orch status` — verify stale detection marks completed/failed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)